### PR TITLE
 modified the provider version and vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "ubuntu" {
   instance_type = var.instance_type
 
   tags = {
-    Name = var.instance_name
+    Name = "${var.name}-ec2-instance"
+    Email = var.email
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,8 +8,11 @@ variable "instance_type" {
   default     = "t2.micro"
 }
 
-variable "instance_name" {
-  description = "EC2 instance name"
-  default     = "Provisioned by Terraform"
+variable "email" {
+  description = "This is an email tag for easily recognition"  
 }
 
+variable "name" {
+  description = "this is an prefix name for the aws resources"
+  
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,17 +1,17 @@
 terraform {
 
   cloud {
-    organization = "hashicorp-learn"
+    organization = "hashicorp-test-peter"
 
     workspaces {
-      name = "learn-terraform-cloud"
+      name = "peter-tfc-workspace"
     }
   }
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.28.0"
+      version = "~> 4.19.0"
     }
   }
 


### PR DESCRIPTION
I have modified the provider block to use the latest currently available version of AWSas they have specified an old version that was unsupported on Mac M1 architecture:
```
 required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 4.19.0"
    }
  }
```

I personalized the code as well to include my email and my specific name prefix tags.